### PR TITLE
Fix for same column match and results = 1

### DIFF
--- a/pl_fuzzy_frame_match/__init__.py
+++ b/pl_fuzzy_frame_match/__init__.py
@@ -5,7 +5,7 @@ pl-fuzzy-match: Efficient Fuzzy Matching for Polars DataFrames.
 from .matcher import fuzzy_match_dfs  #
 from .models import FuzzyMapping, FuzzyTypeLiteral  #
 
-__version__ = "0.1.3"  # Keep in sync with pyproject.toml
+__version__ = "0.1.4"  # Keep in sync with pyproject.toml
 
 __all__ = [
     "fuzzy_match_dfs",

--- a/pl_fuzzy_frame_match/pre_process.py
+++ b/pl_fuzzy_frame_match/pre_process.py
@@ -1,3 +1,4 @@
+from copy import copy
 from logging import Logger
 from typing import cast
 
@@ -252,7 +253,7 @@ def get_rename_right_columns_to_ensure_no_overlap(
     return renamed_mapping
 
 
-def rename_fuzzy_right_mapping(fuzzy_maps: list[FuzzyMapping], right_rename_dict: dict[str, str]) -> None:
+def rename_fuzzy_right_mapping(fuzzy_maps: list[FuzzyMapping], right_rename_dict: dict[str, str]) -> list[FuzzyMapping]:
     """
     Rename the right column names in fuzzy mappings based on a provided mapping.
 
@@ -264,12 +265,16 @@ def rename_fuzzy_right_mapping(fuzzy_maps: list[FuzzyMapping], right_rename_dict
         right_rename_dict (dict[str, str]): Dictionary mapping original right column names to new names.
 
     Returns:
-        None: The function modifies the fuzzy_maps in place.
+        list[FuzzyMapping]: Updated list of fuzzy mappings with renamed right columns.
     """
+    new_maps = []
     for fuzzy_map in fuzzy_maps:
+        new_map = copy(fuzzy_map)
         new_right_name = right_rename_dict.get(fuzzy_map.right_col)
         if new_right_name:
-            fuzzy_map.right_col = new_right_name
+            new_map.right_col = new_right_name
+        new_maps.append(new_map)
+    return new_maps
 
 
 def pre_process_for_fuzzy_matching(
@@ -316,5 +321,5 @@ def pre_process_for_fuzzy_matching(
         left_df, right_df = aggregate_output(left_df, right_df, fuzzy_maps)
     logger.info("Data and settings optimized for fuzzy matching")
     right_rename_dict = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
-    rename_fuzzy_right_mapping(fuzzy_maps, right_rename_dict)
+    fuzzy_maps = rename_fuzzy_right_mapping(fuzzy_maps, right_rename_dict)
     return left_df, right_df.rename(right_rename_dict), fuzzy_maps

--- a/pl_fuzzy_frame_match/pre_process.py
+++ b/pl_fuzzy_frame_match/pre_process.py
@@ -197,7 +197,7 @@ def report_on_order_of_fuzzy_maps(fuzzy_maps: list[FuzzyMapping], logger: Logger
 
 
 def get_rename_right_columns_to_ensure_no_overlap(
-        left_df: pl.LazyFrame, right_df: pl.LazyFrame, suffix: str = "_right"
+    left_df: pl.LazyFrame, right_df: pl.LazyFrame, suffix: str = "_right"
 ) -> dict[str, str]:
     """
     Compute column renaming mapping to ensure no overlap between dataframes.

--- a/pl_fuzzy_frame_match/process.py
+++ b/pl_fuzzy_frame_match/process.py
@@ -43,9 +43,6 @@ def calculate_fuzzy_score(
     mapping_table = mapping_table.with_columns(
         pl.col(left_col_name).str.to_lowercase().alias("left"), pl.col(right_col_name).str.to_lowercase().alias("right")
     )
-    mapping_table = mapping_table.with_columns(
-        pl.col(left_col_name).str.to_lowercase().alias("left"), pl.col(right_col_name).str.to_lowercase().alias("right")
-    )
     dist_col = pld.DistancePairWiseString(pl.col("left"))
     if fuzzy_method in ("jaro_winkler"):
         fm_method = getattr(dist_col, fuzzy_method)(pl.col("right")).alias("s")
@@ -92,7 +89,6 @@ def process_fuzzy_frames(
         - Caches intermediate results to temporary storage to avoid recomputation
         - The returned lengths represent unique value counts, not row counts
     """
-
     # Process left and right data frames
     left_fuzzy_frame = cache_polars_frame_to_temp(
         left_df.group_by(left_col_name).agg("__left_index").filter(pl.col(left_col_name).is_not_null()), temp_dir_ref

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pl-fuzzy-frame-match"
-version = "0.1.3"
+version = "0.1.4"
 description = "Efficient fuzzy matching for Polars DataFrames with support for multiple string similarity algorithms"
 authors = ["Edward van Eechoud <evaneechoud@gmail.com>"]
 license = "MIT"

--- a/tests/test_pl_fuzzy_frame_match.py
+++ b/tests/test_pl_fuzzy_frame_match.py
@@ -366,10 +366,14 @@ def test_fuzzy_match_dfs(logger):
 def test_fuzzy_match_dfs_equal_column_names(logger):
     left_df, right_df, mapping = generate_small_fuzzy_test_data()
     left_df = left_df.rename({"company_name": "organization"})
-
     mapping[0].left_col = "organization"
     mapping[0].right_col = "organization"
-
+    assert (fuzzy_match_dfs(
+        left_df.lazy(),
+        right_df.lazy(),
+        [mapping[0]],
+        logger).select("fuzzy_score_0").unique().select(pl.len())[0,0])>1,\
+        "Expected multiple matches for equal column names"
     result = fuzzy_match_dfs(left_df.lazy(), right_df.lazy(), mapping, logger)
     result = result.sort("id")
     assert result is not None

--- a/tests/test_pl_fuzzy_frame_match.py
+++ b/tests/test_pl_fuzzy_frame_match.py
@@ -363,6 +363,40 @@ def test_fuzzy_match_dfs(logger):
     assert result.equals(expected_match_data), "Unexpected match data"
 
 
+def test_fuzzy_match_dfs_equal_column_names(logger):
+    left_df, right_df, mapping = generate_small_fuzzy_test_data()
+    left_df = left_df.rename({"company_name": "organization"})
+
+    mapping[0].left_col = "organization"
+    mapping[0].right_col = "organization"
+
+    result = fuzzy_match_dfs(left_df.lazy(), right_df.lazy(), mapping, logger)
+    result = result.sort("id")
+    assert result is not None
+    expected_match_data = pl.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "company_name": ["Apple Inc.", "Microsft", "Amazon", "Gogle", "Facebok"],
+            "address": ["1 Apple Park", "One Microsoft Way", "410 Terry Ave N", "1600 Amphitheatre", "1 Hacker Way"],
+            "contact": ["Tim Cook", "Satya Ndella", "Andy Jessy", "Sundar Pichai", "Mark Zukerberg"],
+            "fuzzy_score_0": [0.88, 0.9142857142857143, 0.8857142857142858, 0.8666666666666667, 0.9166666666666667],
+            "fuzzy_score_1": [0.6666666666666667, 0.9230769230769231, 0.9, 1.0, 0.9333333333333333],
+            "id_right": [101, 102, 103, 104, 105],
+            "right_company_name":
+                ["Apple Incorporated", "Microsoft Corp", "Amazon.com Inc", "Google LLC", "Facebook Inc"],
+            "location": [
+                "Apple Park, Cupertino",
+                "Microsoft Way, Redmond",
+                "Terry Ave North, Seattle",
+                "Amphitheatre Pkwy, Mountain View",
+                "Hacker Way, Menlo Park",
+            ],
+            "ceo": ["Timothy Cook", "Satya Nadella", "Andy Jassy", "Sundar Pichai", "Mark Zuckerberg"],
+        }
+    )
+    assert result.equals(expected_match_data), "Unexpected match data"
+
+
 def test_unique_df_large(temp_directory):
     """Test the unique_df_large function for handling large dataframes with duplicates."""
     # Create a sample dataframe with intentional duplicates

--- a/tests/test_pl_fuzzy_frame_match.py
+++ b/tests/test_pl_fuzzy_frame_match.py
@@ -380,13 +380,13 @@ def test_fuzzy_match_dfs_equal_column_names(logger):
     expected_match_data = pl.DataFrame(
         {
             "id": [1, 2, 3, 4, 5],
-            "company_name": ["Apple Inc.", "Microsft", "Amazon", "Gogle", "Facebok"],
+            "organization": ["Apple Inc.", "Microsft", "Amazon", "Gogle", "Facebok"],
             "address": ["1 Apple Park", "One Microsoft Way", "410 Terry Ave N", "1600 Amphitheatre", "1 Hacker Way"],
             "contact": ["Tim Cook", "Satya Ndella", "Andy Jessy", "Sundar Pichai", "Mark Zukerberg"],
             "fuzzy_score_0": [0.88, 0.9142857142857143, 0.8857142857142858, 0.8666666666666667, 0.9166666666666667],
             "fuzzy_score_1": [0.6666666666666667, 0.9230769230769231, 0.9, 1.0, 0.9333333333333333],
             "id_right": [101, 102, 103, 104, 105],
-            "right_company_name":
+            "organization_right":
                 ["Apple Incorporated", "Microsoft Corp", "Amazon.com Inc", "Google LLC", "Facebook Inc"],
             "location": [
                 "Apple Park, Cupertino",

--- a/tests/test_pre_process.py
+++ b/tests/test_pre_process.py
@@ -15,8 +15,11 @@ from pl_fuzzy_frame_match.pre_process import (
     fill_perc_unique_in_fuzzy_maps,
     get_approx_uniqueness,
     pre_process_for_fuzzy_matching,
+    get_rename_right_columns_to_ensure_no_overlap,
+    rename_fuzzy_right_mapping,
 )
 
+from pl_fuzzy_frame_match.models import FuzzyMapping
 from .match_utils import create_fuzzy_maps, create_test_data
 
 
@@ -30,6 +33,62 @@ def sample_dataframe():
         "country": ["USA", "USA", "USA", "Canada"],
     }
     return pl.DataFrame(data).lazy()
+
+
+@pytest.fixture
+def simple_dataframes():
+    """Create simple test dataframes."""
+    left_df = pl.DataFrame({
+        "id": [1, 2, 3],
+        "name": ["A", "B", "C"],
+        "value": [10, 20, 30]
+    }).lazy()
+
+    right_df = pl.DataFrame({
+        "id": [4, 5, 6],
+        "category": ["X", "Y", "Z"],
+        "score": [100, 200, 300]
+    }).lazy()
+
+    return left_df, right_df
+
+
+@pytest.fixture
+def complex_overlap_dataframes():
+    """Create dataframes with complex overlap scenarios."""
+    left_df = pl.DataFrame({
+        "id": [1, 2],
+        "id_right": [10, 20],
+        "id_right_right": [100, 200],
+        "name": ["A", "B"]
+    }).lazy()
+
+    right_df = pl.DataFrame({
+        "id": [3, 4],
+        "id_right": [30, 40],
+        "value": [300, 400],
+        "name": ["C", "D"]
+    }).lazy()
+
+    return left_df, right_df
+
+
+@pytest.fixture
+def self_conflicting_dataframes():
+    """Create dataframes where right_df has internal conflicts after renaming."""
+    left_df = pl.DataFrame({
+        "id": [1, 2],
+        "value": [10, 20]
+    }).lazy()
+
+    right_df = pl.DataFrame({
+        "id": [3, 4],
+        "id_right": [30, 40],  # This would be the natural rename for "id"
+        "value": [300, 400],
+        "value_right": [3000, 4000]  # This would be the natural rename for "value"
+    }).lazy()
+
+    return left_df, right_df
 
 
 @pytest.fixture
@@ -124,3 +183,252 @@ def test_process_fuzzy_mapping_uniqueness(flow_logger):
     left_df_prep, right_df_prep, mapping = pre_process_for_fuzzy_matching(left_df, right_df, mapping, flow_logger)
     assert left_df_prep.collect().shape[0] == left_df.select(pl.first()).collect().shape[0]
     assert right_df_prep.collect().shape[0] == right_df.select(pl.first()).collect().shape[0]
+
+
+# Test cases
+def test_simple_column_overlap(simple_dataframes):
+    """Test basic column overlap scenario."""
+    left_df, right_df = simple_dataframes
+
+    mapping = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
+
+    # Check that only "id" was renamed
+    assert mapping == {"id": "id_right"}
+
+    # Verify that applying the mapping works correctly
+    renamed_df = right_df.rename(mapping)
+    assert set(renamed_df.columns) == {"id_right", "category", "score"}
+
+    # Ensure no overlap with left_df after renaming
+    assert len(set(renamed_df.columns).intersection(set(left_df.columns))) == 0
+
+
+def test_no_overlap_scenario():
+    """Test when there's no overlap between dataframes."""
+    left_df = pl.DataFrame({"a": [1], "b": [2]}).lazy()
+    right_df = pl.DataFrame({"c": [3], "d": [4]}).lazy()
+
+    mapping = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
+
+    # No columns should need renaming
+    assert mapping == {}
+
+
+def test_complete_overlap():
+    """Test when all columns overlap."""
+    left_df = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).lazy()
+    right_df = pl.DataFrame({"a": [4], "b": [5], "c": [6]}).lazy()
+
+    mapping = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
+
+    # All columns should be mapped for renaming
+    assert mapping == {"a": "a_right", "b": "b_right", "c": "c_right"}
+
+
+def test_recursive_suffix_addition(complex_overlap_dataframes):
+    """Test recursive suffix addition for already-suffixed columns."""
+    left_df, right_df = complex_overlap_dataframes
+
+    mapping = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
+
+    # "id" should get multiple suffixes since "id_right" exists in both
+    # "id_right" should also be renamed since it exists in left
+    # "name" should be renamed normally
+    assert mapping == {
+        "id": "id_right_right_right",  # id_right and id_right_right already exist
+        "id_right": "id_right_right_right_right",  # Needs even more suffixes
+        "name": "name_right"
+    }
+
+
+def test_self_conflicting_rename(self_conflicting_dataframes):
+    """Test when renaming would conflict with existing right_df columns."""
+    left_df, right_df = self_conflicting_dataframes
+
+    mapping = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
+
+    # "id" can't become "id_right" because it already exists in right_df
+    # "value" can't become "value_right" for the same reason
+    assert mapping == {
+        "id": "id_right_right",
+        "value": "value_right_right"
+    }
+
+
+def test_custom_suffix():
+    """Test with a custom suffix."""
+    left_df = pl.DataFrame({"id": [1], "name": [2]}).lazy()
+    right_df = pl.DataFrame({"id": [3], "value": [4]}).lazy()
+
+    mapping = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df, suffix="_r")
+
+    assert mapping == {"id": "id_r"}
+
+
+def test_mapping_correctness_with_cross_join():
+    """Test that the mapping enables safe cross joins."""
+    left_df = pl.DataFrame({
+        "id": [1, 2],
+        "name": ["A", "B"]
+    }).lazy()
+
+    right_df = pl.DataFrame({
+        "id": [10, 20],
+        "name": ["X", "Y"],
+        "value": [100, 200]
+    }).lazy()
+
+    mapping = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
+
+    # Apply the mapping
+    right_renamed = right_df.rename(mapping)
+
+    # Perform cross join - should not raise any errors
+    result = left_df.join(right_renamed, how="cross")
+
+    # Verify all columns are present and unique
+    expected_columns = {"id", "name", "id_right", "name_right", "value"}
+    assert set(result.columns) == expected_columns
+
+
+def test_large_suffix_chain():
+    """Test extreme case with very long suffix chains."""
+    # Create a pathological case
+    columns = ["id"] + [f"id{'_right' * i}" for i in range(1, 6)]
+
+    left_df = pl.DataFrame({col: [1] for col in columns}).lazy()
+    right_df = pl.DataFrame({"id": [2], "value": [3]}).lazy()
+
+    mapping = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
+
+    # "id" should get 6 "_right" suffixes
+    assert mapping == {"id": "id" + "_right" * 6}
+
+
+def test_partial_overlap_maintains_order():
+    """Test that non-overlapping columns are not in the mapping."""
+    left_df = pl.DataFrame({"b": [1], "d": [2]}).lazy()
+    right_df = pl.DataFrame({"a": [3], "b": [4], "c": [5], "d": [6]}).lazy()
+
+    mapping = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
+
+    # Only overlapping columns should be in the mapping
+    assert mapping == {"b": "b_right", "d": "d_right"}
+    assert "a" not in mapping
+    assert "c" not in mapping
+
+
+def test_empty_suffix_raises_error():
+    """Test that empty suffix raises ValueError."""
+    left_df = pl.DataFrame({"id": [1]}).lazy()
+    right_df = pl.DataFrame({"id": [2]}).lazy()
+
+    with pytest.raises(ValueError, match="Suffix must not be empty"):
+        get_rename_right_columns_to_ensure_no_overlap(left_df, right_df, suffix="")
+
+
+def test_integration_with_fuzzy_matching_preprocessing():
+    """Test integration similar to fuzzy matching preprocessing."""
+    # Simulate fuzzy matching scenario from pre_process_for_fuzzy_matching
+    left_df = pl.DataFrame({
+        "organization": ["Apple Inc.", "Microsoft"],
+        "contact": ["Tim Cook", "Satya Nadella"],
+        "id": [1, 2]
+    }).lazy()
+
+    right_df = pl.DataFrame({
+        "organization": ["Apple", "MSFT"],
+        "ceo": ["Cook", "Nadella"],
+        "id": [101, 102]
+    }).lazy()
+    # Get the mapping
+    mapping = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
+
+    # Verify the mapping is correct
+    assert mapping == {
+        "organization": "organization_right",
+        "id": "id_right"
+    }
+
+    # Apply mapping and verify it enables safe operations
+    right_renamed = right_df.rename(mapping)
+
+    # All columns should now be unique across both dataframes
+    all_columns = set(left_df.columns).union(set(right_renamed.columns))
+    assert len(all_columns) == 6  # 3 from left + 3 from right (renamed)
+
+
+def test_multiple_dataframes_scenario():
+    """Test scenario where we need to rename multiple dataframes sequentially."""
+    df1 = pl.DataFrame({"id": [1], "value": [10]}).lazy()
+    df2 = pl.DataFrame({"id": [2], "value": [20], "score": [100]}).lazy()
+    df3 = pl.DataFrame({"id": [3], "value": [30], "id_right": [300]}).lazy()
+
+    # First merge: df1 with df2
+    mapping1 = get_rename_right_columns_to_ensure_no_overlap(df1, df2)
+    df2_renamed = df2.rename(mapping1)
+    combined = df1.join(df2_renamed, how="cross")
+
+    # Second merge: combined with df3
+    mapping2 = get_rename_right_columns_to_ensure_no_overlap(combined, df3)
+    df3_renamed = df3.rename(mapping2)
+
+    # Verify all columns are unique
+    final_columns = set(combined.columns).union(set(df3_renamed.columns))
+    assert len(final_columns) == 8  # All columns should be unique
+
+    # Check specific mappings
+    assert mapping1 == {"id": "id_right", "value": "value_right"}
+    assert mapping2 == {"id": "id_right_right", "value": "value_right_right", "id_right": "id_right_right_right"}
+
+
+def test_rename_fuzzy_mapping_with_overlaps():
+    """Test renaming fuzzy mappings when columns need to be renamed."""
+    # Create fuzzy mappings
+    fuzzy_maps = [
+        FuzzyMapping(left_col="organization", right_col="organization", perc_unique=0.8),
+        FuzzyMapping(left_col="contact", right_col="ceo", perc_unique=0.9),
+        FuzzyMapping(left_col="id", right_col="id", perc_unique=1.0),
+    ]
+
+    # Define rename dictionary (simulating overlapping columns)
+    right_rename_dict = {
+        "organization": "organization_right",
+        "id": "id_right"
+    }
+
+    # Apply renaming
+    updated_maps = rename_fuzzy_right_mapping(fuzzy_maps, right_rename_dict)
+
+    # Verify the mappings were updated correctly
+    assert updated_maps[0].right_col == "organization_right"
+    assert updated_maps[1].right_col == "ceo"  # Should remain unchanged
+    assert updated_maps[2].right_col == "id_right"
+
+    # Verify other attributes remain unchanged
+    assert updated_maps[0].left_col == "organization"
+    assert updated_maps[0].perc_unique == 0.8
+
+
+def test_rename_fuzzy_mapping_no_overlaps():
+    """Test renaming fuzzy mappings when no columns need to be renamed."""
+    # Create fuzzy mappings
+    fuzzy_maps = [
+        FuzzyMapping(left_col="name", right_col="company_name", perc_unique=0.7),
+        FuzzyMapping(left_col="address", right_col="location", perc_unique=0.6),
+        FuzzyMapping(left_col="contact", right_col="ceo", perc_unique=0.9),
+    ]
+
+    # Empty rename dictionary (no overlaps)
+    right_rename_dict = {}
+
+    # Apply renaming
+    updated_maps = rename_fuzzy_right_mapping(fuzzy_maps, right_rename_dict)
+
+    # Verify nothing was changed
+    assert updated_maps[0].right_col == "company_name"
+    assert updated_maps[1].right_col == "location"
+    assert updated_maps[2].right_col == "ceo"
+
+    # Verify the function returns the same list object
+    assert updated_maps is fuzzy_maps

--- a/tests/test_pre_process.py
+++ b/tests/test_pre_process.py
@@ -428,4 +428,3 @@ def test_rename_fuzzy_mapping_no_overlaps():
     assert updated_maps[0].right_col == "company_name"
     assert updated_maps[1].right_col == "location"
     assert updated_maps[2].right_col == "ceo"
-

--- a/tests/test_pre_process.py
+++ b/tests/test_pre_process.py
@@ -424,11 +424,8 @@ def test_rename_fuzzy_mapping_no_overlaps():
 
     # Apply renaming
     updated_maps = rename_fuzzy_right_mapping(fuzzy_maps, right_rename_dict)
-
     # Verify nothing was changed
     assert updated_maps[0].right_col == "company_name"
     assert updated_maps[1].right_col == "location"
     assert updated_maps[2].right_col == "ceo"
 
-    # Verify the function returns the same list object
-    assert updated_maps is fuzzy_maps


### PR DESCRIPTION

This pull request introduces functionality to handle column name conflicts between dataframes during preprocessing for fuzzy matching. As was found in #3 

The key changes include adding utilities for column renaming to avoid overlaps, integrating these utilities into the preprocessing pipeline, and creating extensive tests to ensure correctness and robustness.

### New utilities for column renaming:

* [`pl_fuzzy_frame_match/pre_process.py`](diffhunk://#diff-8d299ccf467003644ea2af490aa0feb575238edf8d1fbc1c2a34a2752b039c11R198-R274): Added `get_rename_right_columns_to_ensure_no_overlap` to compute a mapping for renaming columns in the right dataframe to avoid conflicts with the left dataframe. Also added `rename_fuzzy_right_mapping` to update `FuzzyMapping` objects with the new column names.

### Integration into preprocessing pipeline:

* [`pl_fuzzy_frame_match/pre_process.py`](diffhunk://#diff-8d299ccf467003644ea2af490aa0feb575238edf8d1fbc1c2a34a2752b039c11L241-R320): Updated `pre_process_for_fuzzy_matching` to use the new renaming utilities, ensuring no column name conflicts between the left and right dataframes.

### Code simplifications:

* [`pl_fuzzy_frame_match/process.py`](diffhunk://#diff-d732afddad910ab439dd589e7e55afa75c82fba2945c16f743998c9b1acdf377L46-L48): Removed redundant code in `calculate_fuzzy_score` and cleaned up whitespace in `process_fuzzy_frames`. [[1]](diffhunk://#diff-d732afddad910ab439dd589e7e55afa75c82fba2945c16f743998c9b1acdf377L46-L48) [[2]](diffhunk://#diff-d732afddad910ab439dd589e7e55afa75c82fba2945c16f743998c9b1acdf377L95)

### New test cases:

* [`tests/test_pre_process.py`](diffhunk://#diff-80f14207ee430d3d760631a5c919940c1bf72beac14a128513070712b143e4cfR18-R22): Added comprehensive test cases for the renaming utilities, covering scenarios like simple overlaps, no overlaps, recursive suffix addition, self-conflicting renames, and custom suffixes. Also added integration tests to validate the preprocessing pipeline. [[1]](diffhunk://#diff-80f14207ee430d3d760631a5c919940c1bf72beac14a128513070712b143e4cfR18-R22) [[2]](diffhunk://#diff-80f14207ee430d3d760631a5c919940c1bf72beac14a128513070712b143e4cfR38-R93) [[3]](diffhunk://#diff-80f14207ee430d3d760631a5c919940c1bf72beac14a128513070712b143e4cfR186-R434)

### Additional integration test:

* [`tests/test_pl_fuzzy_frame_match.py`](diffhunk://#diff-154cf5ac9ec78f24af96299d887949b130d9387eeb9e9882791805e9c935d1e0R366-R399): Added a test for fuzzy matching with overlapping column names to ensure the new renaming logic works as expected.