### PR TITLE
making a logger optional

### DIFF
--- a/pl_fuzzy_frame_match/_utils.py
+++ b/pl_fuzzy_frame_match/_utils.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 import uuid
 from typing import cast
 

--- a/pl_fuzzy_frame_match/_utils.py
+++ b/pl_fuzzy_frame_match/_utils.py
@@ -1,12 +1,11 @@
 import logging
 import os
+import sys
 import uuid
 from typing import cast
 
 import polars as pl
 from polars.exceptions import PanicException
-
-logger = logging.getLogger(__name__)
 
 
 def collect_lazy_frame(lf: pl.LazyFrame) -> pl.DataFrame:
@@ -118,3 +117,6 @@ def cache_polars_frame_to_temp(_df: pl.LazyFrame | pl.DataFrame, tempdir: str | 
         return df.lazy()
     else:
         raise Exception("Could not cache the data")
+
+
+logger = logging.getLogger(__name__)

--- a/pl_fuzzy_frame_match/matcher.py
+++ b/pl_fuzzy_frame_match/matcher.py
@@ -2,7 +2,7 @@ import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
 from logging import Logger, getLogger
-from typing import cast, Optional
+from typing import cast
 
 import polars as pl
 import polars_simed as ps
@@ -657,7 +657,7 @@ def fuzzy_match_dfs(
     left_df: pl.LazyFrame,
     right_df: pl.LazyFrame,
     fuzzy_maps: list[FuzzyMapping],
-    logger: Optional[Logger] = None,
+    logger: Logger | None = None,
     use_appr_nearest_neighbor_for_new_matches: bool | None = None,
     top_n_for_new_matches: int = 500,
     cross_over_for_appr_nearest_neighbor: int = 100_000_000,

--- a/pl_fuzzy_frame_match/matcher.py
+++ b/pl_fuzzy_frame_match/matcher.py
@@ -1,8 +1,8 @@
 import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
-from logging import Logger
-from typing import cast
+from logging import Logger, getLogger
+from typing import cast, Optional
 
 import polars as pl
 import polars_simed as ps
@@ -657,7 +657,7 @@ def fuzzy_match_dfs(
     left_df: pl.LazyFrame,
     right_df: pl.LazyFrame,
     fuzzy_maps: list[FuzzyMapping],
-    logger: Logger,
+    logger: Optional[Logger] = None,
     use_appr_nearest_neighbor_for_new_matches: bool | None = None,
     top_n_for_new_matches: int = 500,
     cross_over_for_appr_nearest_neighbor: int = 100_000_000,
@@ -672,7 +672,7 @@ def fuzzy_match_dfs(
         left_df (pl.LazyFrame): Left dataframe to be matched.
         right_df (pl.LazyFrame): Right dataframe to be matched.
         fuzzy_maps (list[FuzzyMapping]): A list of fuzzy mapping configurations to apply sequentially.
-        logger (Logger): Logger instance for tracking progress.
+        logger (Logger | None, optional): Logger instance for tracking progress.
         use_appr_nearest_neighbor_for_new_matches (bool | None, optional):
             Controls the join strategy for generating initial candidate pairs when no prior
             matches exist.
@@ -692,6 +692,8 @@ def fuzzy_match_dfs(
         pl.DataFrame: The final matched dataframe containing original data from both
                       dataframes along with all calculated fuzzy scores.
     """
+    if logger is None:
+        logger = getLogger(__name__)
     left_df, right_df, fuzzy_maps = pre_process_for_fuzzy_matching(left_df, right_df, fuzzy_maps, logger)
 
     # Create a temporary directory for caching intermediate results


### PR DESCRIPTION
This pull request introduces improvements to logging flexibility and organization in the `pl_fuzzy_frame_match` package. The main changes are making the logger optional in the `fuzzy_match_dfs` function and ensuring a default logger is used if none is provided, as well as minor import and logger initialization adjustments.

**Logging improvements:**

* The `logger` parameter in `fuzzy_match_dfs` is now optional (`Optional[Logger]`), and if not provided, a default logger for the module is used. This makes the function easier to use and more robust in different contexts. [[1]](diffhunk://#diff-35ea8a9cc9e0ec8b9a1431ef03f0164feef4cbb86af4b5747e34e5888e845a42L660-R660) [[2]](diffhunk://#diff-35ea8a9cc9e0ec8b9a1431ef03f0164feef4cbb86af4b5747e34e5888e845a42L675-R675) [[3]](diffhunk://#diff-35ea8a9cc9e0ec8b9a1431ef03f0164feef4cbb86af4b5747e34e5888e845a42R695-R696)
* Updated imports in `matcher.py` to use `getLogger` and `Optional`, aligning with the new logger handling.

**Logger initialization changes:**

* In `_utils.py`, moved the logger initialization to the end of the file and added a missing import for `sys`, improving code organization and consistency. [[1]](diffhunk://#diff-fed0e4b7630698d1f15f62f556b8aaa695f6b311db811a60df90a70327e17f51R3-L10) [[2]](diffhunk://#diff-fed0e4b7630698d1f15f62f556b8aaa695f6b311db811a60df90a70327e17f51R120-R122)