### PR TITLE
Ensure the output is ordered

### DIFF
--- a/pl_fuzzy_frame_match/matcher.py
+++ b/pl_fuzzy_frame_match/matcher.py
@@ -704,9 +704,16 @@ def fuzzy_match_dfs(
     local_temp_dir_ref = local_temp_dir.name
 
     try:
-        lazy_output = fuzzy_match_dfs_with_context(left_df, right_df, fuzzy_maps, logger, local_temp_dir_ref,
-                                                   use_appr_nearest_neighbor_for_new_matches,
-                                                   top_n_for_new_matches, cross_over_for_appr_nearest_neighbor)
+        lazy_output = fuzzy_match_dfs_with_context(
+            left_df,
+            right_df,
+            fuzzy_maps,
+            logger,
+            local_temp_dir_ref,
+            use_appr_nearest_neighbor_for_new_matches,
+            top_n_for_new_matches,
+            cross_over_for_appr_nearest_neighbor,
+        )
         return collect_lazy_frame(lazy_output)
 
     except Exception as e:
@@ -741,4 +748,3 @@ def fuzzy_match_temp_dir() -> Generator[str, None, None]:
         yield temp_dir.name
     finally:
         temp_dir.cleanup()
-

--- a/pl_fuzzy_frame_match/output_column_name_utils.py
+++ b/pl_fuzzy_frame_match/output_column_name_utils.py
@@ -1,0 +1,43 @@
+
+from pl_fuzzy_frame_match.models import FuzzyMapping
+
+
+def generate_output_column_from_fuzzy_mapping(fuzzy_mapping: FuzzyMapping) -> str:
+    """
+    Generate a descriptive output column name based on the fuzzy mapping configuration.
+
+    This function creates a standardized output column name that combines the left and right
+    columns involved in the fuzzy matching, along with the fuzzy type and threshold score.
+
+    Args:
+        fuzzy_mapping (FuzzyMapping): The fuzzy mapping configuration containing
+                                       left_col, right_col, fuzzy_type, and threshold_score.
+
+    Returns:
+        str: A formatted string representing the output column name.
+    """
+    return f"{fuzzy_mapping.left_col}_vs_{fuzzy_mapping.right_col}_{fuzzy_mapping.fuzzy_type}"
+
+
+def set_name_in_fuzzy_mappings(fuzzy_mappings: list[FuzzyMapping]) -> None:
+    """
+    Set descriptive output column names for a list of fuzzy mappings.
+
+    This function iterates through each FuzzyMapping in the provided list and
+    assigns a standardized output column name based on the left and right columns,
+    fuzzy type, and threshold score.
+
+    Args:
+        fuzzy_mappings (list[FuzzyMapping]): List of FuzzyMapping objects to process.
+    """
+
+    output_name_counter: dict[str, int] = {}
+    for mapping in fuzzy_mappings:
+        output_name = generate_output_column_from_fuzzy_mapping(mapping)
+        if output_name in output_name_counter:
+            output_name_counter[output_name] += 1
+            final_output_name = output_name + "_" + str(output_name_counter[output_name])
+        else:
+            output_name_counter[output_name] = 0
+            final_output_name = output_name
+        mapping.output_column_name = final_output_name

--- a/pl_fuzzy_frame_match/output_column_name_utils.py
+++ b/pl_fuzzy_frame_match/output_column_name_utils.py
@@ -1,4 +1,3 @@
-
 from pl_fuzzy_frame_match.models import FuzzyMapping
 
 

--- a/pl_fuzzy_frame_match/pre_process.py
+++ b/pl_fuzzy_frame_match/pre_process.py
@@ -6,6 +6,7 @@ import polars as pl
 
 from ._utils import collect_lazy_frame
 from .models import FuzzyMapping
+from .output_column_name_utils import set_name_in_fuzzy_mappings
 
 
 def get_approx_uniqueness(lf: pl.LazyFrame) -> dict[str, int]:
@@ -322,4 +323,5 @@ def pre_process_for_fuzzy_matching(
     logger.info("Data and settings optimized for fuzzy matching")
     right_rename_dict = get_rename_right_columns_to_ensure_no_overlap(left_df, right_df)
     fuzzy_maps = rename_fuzzy_right_mapping(fuzzy_maps, right_rename_dict)
+    set_name_in_fuzzy_mappings(fuzzy_maps)
     return left_df, right_df.rename(right_rename_dict), fuzzy_maps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pl-fuzzy-frame-match"
-version = "0.3.0"
+version = "0.4.0"
 description = "Efficient fuzzy matching for Polars DataFrames with support for multiple string similarity algorithms"
 authors = ["Edward van Eechoud <evaneechoud@gmail.com>"]
 license = "MIT"

--- a/tests/test_output_column_name_utils.py
+++ b/tests/test_output_column_name_utils.py
@@ -1,0 +1,35 @@
+from pl_fuzzy_frame_match.output_column_name_utils import (set_name_in_fuzzy_mappings,
+                                                           generate_output_column_from_fuzzy_mapping)
+from pl_fuzzy_frame_match.models import FuzzyMapping
+from typing import List
+
+
+def test_generate_output_column_from_fuzzy_mapping():
+    fuzzy_mapping = FuzzyMapping(left_col="city", right_col="other_city")
+    output = generate_output_column_from_fuzzy_mapping(fuzzy_mapping)
+    assert output == "city_vs_other_city_levenshtein"
+
+
+def test_set_name_in_fuzzy_mappings_single_value():
+    fuzzy_mapping = FuzzyMapping(left_col="city", right_col="other_city")
+    set_name_in_fuzzy_mappings([fuzzy_mapping])
+    assert fuzzy_mapping.output_column_name == "city_vs_other_city_levenshtein"
+
+
+def test_set_names_multiple_values():
+    fuzzy_mappings = [FuzzyMapping(left_col="a", right_col=str(i)) for i in range(10)]
+    set_name_in_fuzzy_mappings(fuzzy_mappings)
+    for i, fuzzy_mapping in enumerate(fuzzy_mappings):
+        assert fuzzy_mapping.output_column_name == "a_vs_"+str(i)+"_levenshtein"
+
+
+def test_set_names_duplicates():
+    fuzzy_mappings = ([FuzzyMapping(left_col="a", right_col="b") for i in range(10)] +
+                      [FuzzyMapping(left_col="city", right_col="other_city")])
+    set_name_in_fuzzy_mappings(fuzzy_mappings)
+    for i, fuzzy_mapping in enumerate(fuzzy_mappings[:10]):
+        if i > 0:
+            assert fuzzy_mapping.output_column_name == "a_vs_b_levenshtein_" + str(i)
+        else:
+            assert fuzzy_mapping.output_column_name == "a_vs_b_levenshtein"
+    assert fuzzy_mappings[-1].output_column_name == "city_vs_other_city_levenshtein"


### PR DESCRIPTION
This pull request introduces standardized and descriptive output column names for fuzzy matching results, replacing the previous generic naming scheme (e.g., `fuzzy_score_0`, `fuzzy_score_1`). The changes ensure that output columns clearly reflect the columns and fuzzy matching types involved, improving both usability and clarity. The refactor also removes the need to pass an index for naming, and updates tests and the matching logic accordingly.

**Standardization of output column names:**

- Added `pl_fuzzy_frame_match/output_column_name_utils.py` with utilities to generate and assign descriptive output column names based on the columns and fuzzy type involved in each mapping. (`[pl_fuzzy_frame_match/output_column_name_utils.pyR1-R43](diffhunk://#diff-3bda91f1d6f35f5cf568f07d02ba5ab0265bd99798312540f8adc66e696c4862R1-R43)`)
- Integrated `set_name_in_fuzzy_mappings` into the preprocessing step to ensure all `FuzzyMapping` objects have unique, descriptive output column names before matching. (`[[1]](diffhunk://#diff-8d299ccf467003644ea2af490aa0feb575238edf8d1fbc1c2a34a2752b039c11R9)`, `[[2]](diffhunk://#diff-8d299ccf467003644ea2af490aa0feb575238edf8d1fbc1c2a34a2752b039c11R326)`)

**Refactoring and simplification of matching logic:**

- Refactored `process_fuzzy_mapping` and related functions to use the new output column naming, removing the need for an index parameter and enforcing that each mapping has a valid `output_column_name`. (`[[1]](diffhunk://#diff-35ea8a9cc9e0ec8b9a1431ef03f0164feef4cbb86af4b5747e34e5888e845a42L425)`, `[[2]](diffhunk://#diff-35ea8a9cc9e0ec8b9a1431ef03f0164feef4cbb86af4b5747e34e5888e845a42L442)`, `[[3]](diffhunk://#diff-35ea8a9cc9e0ec8b9a1431ef03f0164feef4cbb86af4b5747e34e5888e845a42R495-R504)`, `[[4]](diffhunk://#diff-35ea8a9cc9e0ec8b9a1431ef03f0164feef4cbb86af4b5747e34e5888e845a42L559-L566)`)
- Updated the joining and selection logic in `fuzzy_match_dfs_with_context` to use the new output column names, ensuring result columns are ordered and named appropriately. (`[[1]](diffhunk://#diff-35ea8a9cc9e0ec8b9a1431ef03f0164feef4cbb86af4b5747e34e5888e845a42R624)`, `[[2]](diffhunk://#diff-35ea8a9cc9e0ec8b9a1431ef03f0164feef4cbb86af4b5747e34e5888e845a42R655)`)
- Simplified the main `fuzzy_match_dfs` function by delegating to the context-aware version and removing now-unnecessary manual column naming and joining logic. (`[pl_fuzzy_frame_match/matcher.pyL697-L735](diffhunk://#diff-35ea8a9cc9e0ec8b9a1431ef03f0164feef4cbb86af4b5747e34e5888e845a42L697-L735)`)

**Version bump:**

- Incremented the package version to `0.4.0` to reflect these significant improvements. (`[pyproject.tomlL7-R7](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)`)