### PR TITLE
fix: relax non-windows polars upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ packages = [{include = "pl_fuzzy_frame_match"}]
 python = "^3.10"
 polars = [
     { version = ">=1.8.2, <=1.25.2", markers = "sys_platform == 'win32'" }, # For Windows, max version 1.25.2
-    { version = ">=1.8.2, <1.32.0", markers = "sys_platform != 'win32'" } # For non-Windows, allows 1.26.0 up to (but not including) 2.0.0
-                                                                      # Or whatever your desired range is for other OSes
+    { version = ">=1.8.2, <2.0", markers = "sys_platform != 'win32'" } # For non-Windows, allow current Polars 1.x releases
 ]
 polars-distance = "~0.4.3"
 polars-simed = "^0.3.4"


### PR DESCRIPTION
## Summary
- relax the non-Windows `polars` upper bound to `<2.0`
- remove the stale inline comment that contradicted the actual constraint

## Why
The current published metadata for `0.5.0` pins non-Windows installs to `polars<1.32.0`, which blocks current Polars 1.x releases even though the issue and inline comment indicate that was not the intent.

## Verification
Reproduced locally before the change:

```bash
python -m pip install . 'polars>=1.37.1'
```

Failed with:

```text
ERROR: Cannot install pl-fuzzy-frame-match==0.5.0 and polars>=1.37.1 because these package versions have conflicting dependencies.
pl-fuzzy-frame-match 0.5.0 depends on polars<1.32.0 and >=1.8.2; sys_platform != "win32"
```

After the change, the same install succeeded and imported correctly:

```text
Successfully installed pl-fuzzy-frame-match-0.5.0 polars-1.38.1 ...
polars 1.38.1
package 0.5.0
```